### PR TITLE
Support filename strings longer than 100 characters long

### DIFF
--- a/atalanta.cpp
+++ b/atalanta.cpp
@@ -164,9 +164,9 @@ level g_test_store1[MAXTEST / 10][MAXPI + 1];
 
 
 /* default parameters setting */
-char g_strCctPathFileName[100] = "", g_strTestFileName[100] = "", g_strLogFileName[100] = "", g_strVecFileName[100] = "";
-char g_strFaultFileName[100] = "";
-char g_strCctFileName[100] = "";
+char g_strCctPathFileName[FILENAME_MAX] = "", g_strTestFileName[FILENAME_MAX] = "", g_strLogFileName[FILENAME_MAX] = "", g_strVecFileName[FILENAME_MAX] = "";
+char g_strFaultFileName[FILENAME_MAX] = "";
+char g_strCctFileName[FILENAME_MAX] = "";
 char nameufaults[MAXSTRING] = "";
 char inputmode = 'd';		/* default mode */
 char rptmode = 'y';		/* RPT mode ON */

--- a/main_fsim.cpp
+++ b/main_fsim.cpp
@@ -101,9 +101,9 @@
 // extern caddr_t sbrk();
 
 /* default parameters setting */
-char name1_f[100] = "",name2_f[100] = "",name3_f[100] = "",commandfile_f[100];
-char namecct_f[100] = "";
-char faultname_f[100] = "";
+char name1_f[FILENAME_MAX] = "",name2_f[FILENAME_MAX] = "",name3_f[FILENAME_MAX] = "",commandfile_f[FILENAME_MAX];
+char namecct_f[FILENAME_MAX] = "";
+char faultname_f[FILENAME_MAX] = "";
 char inputmode_f = 'd';		/* default mode */
 char rptmode_f = 'y';		/* RPT mode ON */
 char logmode_f = 'n';		/* LOG off */

--- a/pattern2atp.cpp
+++ b/pattern2atp.cpp
@@ -18,7 +18,7 @@ int main3(int argc, char *argv[])
 	int i = 0,j = 0;
 	int bit_s, bit_vector, num_pattern;
 	int start_flag = 0;
-	char filename[100], s[10000], launch_vector[10000], capture_vector[10000];
+	char filename[FILENAME_MAX], s[10000], launch_vector[10000], capture_vector[10000];
 	char tmp_s[10000];
 	char *position;
 

--- a/sim.cpp
+++ b/sim.cpp
@@ -84,7 +84,7 @@ extern FILE *g_fpLogFile;
 extern int *g_PrimaryIn, *g_PrimaryOut;
 extern FAULTPTR *g_pFaultList;
 extern STACKTYPE g_stack;
-extern char g_strVecFileName[100];
+extern char g_strVecFileName[FILENAME_MAX];
 
 #define checkbit(word,nth) ((word&BITMASK[nth])!=ALL0)
 #define setbit(word,nth) (word|=BITMASK[nth])


### PR DESCRIPTION
### Problem Description
Filename strings are currently defined with the arbitrary size `[100]`. This creates unexpected failures when passing any file path to atalanta that's nested deeper in a filesystem or uses longer descriptive names.

### Failure Example
**Before:**
```
atalanta -f fault.flt -D 2 ../testcases/CAC_longnameeeeeeeeeeeeeeeeeeeeeeee/DC_Basic/b14_C/b14_C_CAC_k_128_1_syn_modified.bench
*** buffer overflow detected ***: terminated
Aborted
```

**After:**
```
../atalanta/fix/atalanta -f fault.flt -D 2 ../testcases/CAC_longn
ameeeeeeeeeeeeeeeeeeeeeeee/DC_Basic/b14_C/b14_C_CAC_k_128_1_syn_modified.bench
before
after
end initialazition
iLastUndetectedFault=0
        *******************************************************
        *                                                     *
        *          Welcome to atalanta (version 2.0)          *
        *                                                     *
        *               Dong S. Ha (ha@vt.edu)                *
        *            Web: http://www.ee.vt.edu/ha             *
        *  Virginia Polytechnic Institute & State University  *
        *                                                     *
        *******************************************************

******   SUMMARY OF TEST PATTERN GENERATION RESULTS   ******
1. Circuit structure
   Name of the circuit                       :
   Number of primary inputs                  : 403
   Number of primary outputs                 : 246
   Number of gates                           : 4079
   Level of the circuit                      : 62

2. ATPG parameters
   Test pattern generation Mode              : DTPG + TC
   Backtrack limit                           : 10
   Initial random number generator seed      : 1715091717
   Test pattern compaction Mode              : NONE

3. Test pattern generation results
   Number of test patterns                   : 2
   Fault coverage                            : 100.000 %
   Number of collapsed faults                : 1
   Number of identified redundant faults     : 0
   Number of aborted faults                  : 0
   Total number of backtrackings             : 0

4. Memory used                               : 0.000 MB

5. CPU time
   Initialization                            : 0.000 Secs
   Fault simulation                          : 0.000 Secs
   FAN                                       : 0.000 Secs
   Total                                     : 0.000 Secs
```

### Solution Description
This is just a simple find-and-replace of all examples of this I could find in the code. As far as I'm aware this replaces all instances of this behavior, and runs perfectly on all my use cases, but I'm no expert on the ins-and-outs of this project, so a second opinion is appreciated. I used the C-standard `FILENAME_MAX` as it should work consistently across all platforms, but alternatives like POSIX `PATH_MAX` may be preferred. Thank you :)